### PR TITLE
UI improvements, bug fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -372,3 +372,4 @@ FodyWeavers.xsd
 
 # Claude Code
 .claude/
+/screenshots

--- a/SunFileManager/GUI/Container/PanningImageViewer.xaml
+++ b/SunFileManager/GUI/Container/PanningImageViewer.xaml
@@ -9,10 +9,13 @@
         </Grid.RowDefinitions>
 
         <Border Grid.Row="0" BorderBrush="{DynamicResource ControlElevationBorderBrush}" BorderThickness="1">
-            <ScrollViewer x:Name="scrollViewer"
-                          HorizontalScrollBarVisibility="Auto"
-                          VerticalScrollBarVisibility="Auto"
-                          PanningMode="Both">
+            <Grid>
+                <Rectangle x:Name="bgRect"/>
+                <ScrollViewer x:Name="scrollViewer"
+                              Background="Transparent"
+                              HorizontalScrollBarVisibility="Auto"
+                              VerticalScrollBarVisibility="Auto"
+                              PanningMode="Both">
                 <Grid x:Name="contentGrid">
                     <Grid.LayoutTransform>
                         <ScaleTransform x:Name="imageScale" ScaleX="1" ScaleY="1"/>
@@ -30,7 +33,8 @@
                             VerticalAlignment="Top"
                             IsHitTestVisible="False" />
                 </Grid>
-            </ScrollViewer>
+                </ScrollViewer>
+            </Grid>
         </Border>
 
         <!-- Zoom controls -->
@@ -40,6 +44,7 @@
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="Auto"/>
                 <ColumnDefinition Width="36"/>
+                <ColumnDefinition Width="Auto"/>
             </Grid.ColumnDefinitions>
             <TextBlock Grid.Column="0" Text="−" FontSize="14" VerticalAlignment="Center"
                        Margin="0,0,4,0" Cursor="Hand"
@@ -55,6 +60,13 @@
             <TextBlock Grid.Column="3" x:Name="zoomLabel" Text="100%"
                        VerticalAlignment="Center" TextAlignment="Right"
                        FontSize="11"/>
+            <Button Grid.Column="4" x:Name="btnBgToggle"
+                    Width="22" Height="22" Padding="0" Margin="6,0,0,0"
+                    VerticalAlignment="Center"
+                    Click="btnBgToggle_Click"
+                    ToolTip="Toggle background (Checkerboard / Dark / Light)">
+                <Rectangle x:Name="bgPreview" Width="12" Height="12"/>
+            </Button>
         </Grid>
     </Grid>
 </UserControl>

--- a/SunFileManager/GUI/Container/PanningImageViewer.xaml.cs
+++ b/SunFileManager/GUI/Container/PanningImageViewer.xaml.cs
@@ -4,6 +4,7 @@ using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using System.Windows.Input;
 using System.Windows.Media;
+using System.Windows.Media.Imaging;
 using System.Windows.Shapes;
 using SunFileManager.Converter;
 
@@ -86,6 +87,13 @@ namespace SunFileManager.GUI.Container
                 _currentBitmap = value;
                 displayImage.Source = value != null ? value.ToWpfBitmap() : null;
             }
+        }
+
+        /// <summary>Sets a pre-converted BitmapSource directly, bypassing the Bitmap→BitmapSource conversion.</summary>
+        public BitmapSource ImageSource
+        {
+            get => displayImage.Source as BitmapSource;
+            set => displayImage.Source = value;
         }
 
         private System.Drawing.Bitmap _currentBitmap;

--- a/SunFileManager/GUI/Container/PanningImageViewer.xaml.cs
+++ b/SunFileManager/GUI/Container/PanningImageViewer.xaml.cs
@@ -19,9 +19,56 @@ namespace SunFileManager.GUI.Container
         /// <summary>Raised when the user double-clicks the image.</summary>
         public event MouseButtonEventHandler ImageDoubleClicked;
 
+        // ── Background modes ──────────────────────────────────────────────────────
+        private enum ViewerBackground { Checkerboard, Dark, Light }
+        private ViewerBackground _bgMode = ViewerBackground.Checkerboard;
+
+        private static readonly Brush _checkerBrush = CreateCheckerBrush();
+        private static readonly Brush _darkBrush   = new SolidColorBrush(Color.FromRgb(45,  45,  45 ));
+        private static readonly Brush _lightBrush  = new SolidColorBrush(Color.FromRgb(210, 210, 210));
+
+        private static Brush CreateCheckerBrush()
+        {
+            const int s = 8; // pixels per square
+            var light = new SolidColorBrush(Color.FromRgb(204, 204, 204));
+            var dark  = new SolidColorBrush(Color.FromRgb(148, 148, 148));
+            var drawing = new DrawingGroup();
+            drawing.Children.Add(new GeometryDrawing(light, null, new RectangleGeometry(new Rect(0, 0, s * 2, s * 2))));
+            drawing.Children.Add(new GeometryDrawing(dark,  null, new RectangleGeometry(new Rect(s, 0, s, s))));
+            drawing.Children.Add(new GeometryDrawing(dark,  null, new RectangleGeometry(new Rect(0, s, s, s))));
+            var brush = new DrawingBrush
+            {
+                Drawing      = drawing,
+                TileMode     = TileMode.Tile,
+                Viewport     = new Rect(0, 0, s * 2, s * 2),
+                ViewportUnits = BrushMappingMode.Absolute,
+            };
+            brush.Freeze();
+            return brush;
+        }
+
+        private void ApplyBackground()
+        {
+            Brush brush = _bgMode switch
+            {
+                ViewerBackground.Dark  => _darkBrush,
+                ViewerBackground.Light => _lightBrush,
+                _                      => _checkerBrush,
+            };
+            bgRect.Fill = brush;
+            bgPreview.Fill = brush;
+        }
+
+        private void btnBgToggle_Click(object sender, RoutedEventArgs e)
+        {
+            _bgMode = (ViewerBackground)(((int)_bgMode + 1) % 3);
+            ApplyBackground();
+        }
+
         public PanningImageViewer()
         {
             InitializeComponent();
+            ApplyBackground();
             zoomSlider.Loaded += (s, e) =>
             {
                 var thumb = (zoomSlider.Template.FindName("PART_Track", zoomSlider) as Track)?.Thumb;

--- a/SunFileManager/GUI/MainWindow.xaml.cs
+++ b/SunFileManager/GUI/MainWindow.xaml.cs
@@ -559,6 +559,7 @@ namespace SunFileManager.GUI
                     btnApplyPropertyChanges.Visibility = Visibility.Visible;
                     txtPropertyName.Text = linkp.Name;
                     txtPropertyValueMulti.Text = linkp.Value;
+                    DisplayLinkTarget(linkp);
                     break;
 
                 case SunSubProperty subp
@@ -597,6 +598,40 @@ namespace SunFileManager.GUI
             }
 
             UpdateSelectionTypeLabel();
+        }
+
+        private void DisplayLinkTarget(SunLinkProperty linkp)
+        {
+            var target = linkp.LinkValue;
+            if (target == null) return;
+
+            switch (target)
+            {
+                case SunCanvasProperty canvasp:
+                    panningImageViewer.Visibility = Visibility.Visible;
+                    panningImageViewer.Canvas = canvasp.GetBitmap();
+                    var originProp = canvasp["origin"] as SunLibrary.SunFileLib.Properties.SunVectorProperty;
+                    panningImageViewer.OriginPoint = originProp != null
+                        ? new System.Drawing.Point(originProp.X.Value, originProp.Y.Value)
+                        : (System.Drawing.Point?)null;
+                    break;
+
+                case SunSubProperty subp
+                    when subp.SunProperties?.Count == 1 && subp.SunProperties[0] is SunCanvasProperty:
+                    var soloCanvas = (SunCanvasProperty)subp.SunProperties[0];
+                    panningImageViewer.Visibility = Visibility.Visible;
+                    panningImageViewer.Canvas = soloCanvas.GetBitmap();
+                    var soloOrigin = soloCanvas["origin"] as SunLibrary.SunFileLib.Properties.SunVectorProperty;
+                    panningImageViewer.OriginPoint = soloOrigin != null
+                        ? new System.Drawing.Point(soloOrigin.X.Value, soloOrigin.Y.Value)
+                        : (System.Drawing.Point?)null;
+                    break;
+
+                case SunSoundProperty soundp:
+                    soundPlayer.Visibility = Visibility.Visible;
+                    soundPlayer.SoundProperty = soundp;
+                    break;
+            }
         }
 
         private void ShowScalar(string name, string value)
@@ -660,7 +695,9 @@ namespace SunFileManager.GUI
                 case SunStringProperty strp:
                     strp.Value = txtPropertyValueMulti.Text; break;
                 case SunLinkProperty linkp:
-                    linkp.Value = txtPropertyValueMulti.Text; break;
+                    linkp.Value = txtPropertyValueMulti.Text;
+                    DisplayLinkTarget(linkp);
+                    break;
                 case SunVectorProperty vecp:
                     if (int.TryParse(txtVectorX.Text, out int xv)) vecp.X.Value = xv;
                     if (int.TryParse(txtVectorY.Text, out int yv)) vecp.Y.Value = yv;

--- a/SunFileManager/GUI/MainWindow.xaml.cs
+++ b/SunFileManager/GUI/MainWindow.xaml.cs
@@ -18,6 +18,8 @@ using System.Windows.Input;
 using System.Windows.Interop;
 using System.Windows.Threading;
 using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using SunFileManager.Converter;
 using Wpf.Ui.Appearance;
 using Wpf.Ui.Markup;
 
@@ -38,6 +40,11 @@ namespace SunFileManager.GUI
 
         // ── Context menu ──────────────────────────────────────────────────────────
         private SunContextMenuManager contextMenuManager;
+
+        // ── Animation playback ────────────────────────────────────────────────────
+        private DispatcherTimer _animTimer;
+        private List<(BitmapSource Source, int Delay)> _animFrames;
+        private int _animFrameIndex;
 
         // ── WM_COPYDATA ───────────────────────────────────────────────────────────
         private const uint WM_COPYDATA = 0x004A;
@@ -518,6 +525,7 @@ namespace SunFileManager.GUI
         public void DisplayNodeValue(SunObject obj)
         {
             // Reset all
+            StopAnimation();
             nameRow.Visibility = Visibility.Collapsed;
             scalarValueRow.Visibility = Visibility.Collapsed;
             multiValueRow.Visibility = Visibility.Collapsed;
@@ -560,6 +568,12 @@ namespace SunFileManager.GUI
                     txtPropertyName.Text = linkp.Name;
                     txtPropertyValueMulti.Text = linkp.Value;
                     DisplayLinkTarget(linkp);
+                    break;
+
+                case SunSubProperty animSubp
+                    when animSubp.Parent is SunSubProperty aniParent &&
+                         aniParent.Name.Equals("Ani", StringComparison.OrdinalIgnoreCase):
+                    PlayAnimation(BuildAnimFrames(animSubp));
                     break;
 
                 case SunSubProperty subp
@@ -632,6 +646,60 @@ namespace SunFileManager.GUI
                     soundPlayer.SoundProperty = soundp;
                     break;
             }
+        }
+
+        private List<(BitmapSource Source, int Delay)> BuildAnimFrames(SunSubProperty animNode)
+        {
+            var frames = new List<(BitmapSource, int)>();
+            foreach (var prop in animNode.SunProperties
+                .Where(p => int.TryParse(p.Name, out _))
+                .OrderBy(p => int.Parse(p.Name)))
+            {
+                Bitmap bmp = prop.GetBitmap();
+                if (bmp == null) continue;
+
+                // Resolve the actual canvas to read delay (link forwards GetBitmap but not child props)
+                SunObject canvas = prop is SunLinkProperty lp ? lp.LinkValue : prop;
+                int delay = canvas?["delay"]?.GetInt() ?? 100;
+                if (delay <= 0) delay = 100;
+
+                // Pre-convert once here so the animation tick only swaps an already-ready BitmapSource
+                frames.Add((bmp.ToWpfBitmap(), delay));
+            }
+            return frames;
+        }
+
+        private void PlayAnimation(List<(BitmapSource Source, int Delay)> frames)
+        {
+            if (frames.Count == 0) return;
+            _animFrames = frames;
+            _animFrameIndex = 0;
+            panningImageViewer.Visibility = Visibility.Visible;
+            _animTimer = new DispatcherTimer();
+            _animTimer.Tick += AnimTimer_Tick;
+            ShowAnimFrame();
+        }
+
+        private void ShowAnimFrame()
+        {
+            var (source, delay) = _animFrames[_animFrameIndex];
+            panningImageViewer.ImageSource = source;
+            _animTimer.Interval = TimeSpan.FromMilliseconds(delay);
+            _animTimer.Start();
+        }
+
+        private void AnimTimer_Tick(object sender, EventArgs e)
+        {
+            _animTimer.Stop();
+            _animFrameIndex = (_animFrameIndex + 1) % _animFrames.Count;
+            ShowAnimFrame();
+        }
+
+        private void StopAnimation()
+        {
+            _animTimer?.Stop();
+            _animTimer = null;
+            _animFrames = null;
         }
 
         private void ShowScalar(string name, string value)

--- a/SunLibrary/SunFileLib/Properties/SunLinkProperty.cs
+++ b/SunLibrary/SunFileLib/Properties/SunLinkProperty.cs
@@ -87,26 +87,23 @@ namespace SunLibrary.SunFileLib.Properties
 
         #region Cast Values
 
-        public override int GetInt() => 0;
+        public override int GetInt() => LinkValue?.GetInt() ?? 0;
 
-        public override short GetShort() => 0;
+        public override short GetShort() => LinkValue?.GetShort() ?? 0;
 
-        public override long GetLong() => 0;
+        public override long GetLong() => LinkValue?.GetLong() ?? 0;
 
-        public override float GetFloat() => 0f;
+        public override float GetFloat() => LinkValue?.GetFloat() ?? 0f;
 
-        public override double GetDouble() => 0d;
+        public override double GetDouble() => LinkValue?.GetDouble() ?? 0d;
 
-        public override string GetString()
-        {
-            return val;
-        }
+        public override string GetString() => val;  // raw path string; use LinkValue for the resolved target
 
-        public override Point GetPoint() => Point.Empty;
+        public override Point GetPoint() => LinkValue?.GetPoint() ?? Point.Empty;
 
-        public override Bitmap GetBitmap() => null;
+        public override Bitmap GetBitmap() => LinkValue?.GetBitmap();
 
-        public override byte[] GetBytes() => null;
+        public override byte[] GetBytes() => LinkValue?.GetBytes();
 
         public override string ToString()
         {
@@ -156,7 +153,7 @@ namespace SunLibrary.SunFileLib.Properties
         public string Value
         {
             get { return val; }
-            set { val = value; ParentImage.Changed = true; }
+            set { val = value; linkValue = null; ParentImage.Changed = true; }
         }
 
         public SunObject LinkValue
@@ -165,29 +162,17 @@ namespace SunLibrary.SunFileLib.Properties
             {
                 if (linkValue == null)
                 {
-                    string[] paths = val.Split('/');
                     linkValue = parent;
-                    foreach (string path in paths)
+                    foreach (string path in val.Split('/'))
                     {
+                        if (linkValue == null) break;
                         if (path == "..")
-                        {
-                            linkValue = Parent;
-                        }
-                        else
-                        {
-                            if (linkValue is SunProperty)
-                                linkValue = ((SunProperty)linkValue)[path];
-                            else if (linkValue is SunImage)
-                                linkValue = ((SunImage)linkValue)[path];
-                            else if (linkValue is SunDirectory)
-                                linkValue = ((SunDirectory)linkValue)[path];
-                            else
-                            {
-                                ErrorLogger.Log(ErrorLevel.Critical, "Link property is corrupted at property: " + FullPath);
-                                return null;
-                            }
-                        }
+                            linkValue = linkValue.Parent;
+                        else if (path.Length > 0)
+                            linkValue = linkValue[path];
                     }
+                    if (linkValue == null)
+                        ErrorLogger.Log(ErrorLevel.Critical, "Link property could not be resolved: " + FullPath + " -> " + val);
                 }
                 return linkValue;
             }


### PR DESCRIPTION
 - Fix SunLinkProperty '..' navigation bug and path resolution; GetXxx() methods
    now forward to resolved target; UI shows live canvas/sound preview when selecting
    a link node, updates on Apply
  - Selecting a numbered sub-node under 'Ani' plays the animation using per-frame
    delays (defaults to 100ms); frames pre-converted to avoid per-tick jank
  - Image viewer background toggle cycles Checkerboard / Dark / Light for better
    visibility of white and transparent sprites